### PR TITLE
fix missing searchPic response

### DIFF
--- a/Lab7-Integrate_LUIS/02-LUIS_Integrate_Bot.md
+++ b/Lab7-Integrate_LUIS/02-LUIS_Integrate_Bot.md
@@ -140,6 +140,10 @@ default:
             await MainResponses.ReplyWithShareConfirmation(stepContext.Context);
             await MainResponses.ReplyWithLuisScore(stepContext.Context, topIntent.Value.intent, topIntent.Value.score);
             break;
+        case "SearchPic":
+            await MainResponses.ReplyWithSearchConfirmation(stepContext.Context);
+            await MainResponses.ReplyWithLuisScore(stepContext.Context, topIntent.Value.intent, topIntent.Value.score);
+            break;
         default:
             await MainResponses.ReplyWithConfused(stepContext.Context);
             break;

--- a/Lab7-Integrate_LUIS/code/Finished/Bots/PictureBot.cs
+++ b/Lab7-Integrate_LUIS/code/Finished/Bots/PictureBot.cs
@@ -206,6 +206,10 @@ namespace PictureBot.Bots
                                 await MainResponses.ReplyWithShareConfirmation(stepContext.Context);
                                 await MainResponses.ReplyWithLuisScore(stepContext.Context, topIntent.Value.intent, topIntent.Value.score);
                                 break;
+                            case "SearchPic":
+                                await MainResponses.ReplyWithSearchConfirmation(stepContext.Context);
+                                await MainResponses.ReplyWithLuisScore(stepContext.Context, topIntent.Value.intent, topIntent.Value.score);
+                                break;
                             default:
                                 await MainResponses.ReplyWithConfused(stepContext.Context);
                                 break;

--- a/Lab7-Integrate_LUIS/code/Finished/PictureBot.csproj
+++ b/Lab7-Integrate_LUIS/code/Finished/PictureBot.csproj
@@ -7,9 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.Search" Version="9.1.0" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.5.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.5.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.7.2" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.5.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.5.1" />
   </ItemGroup>

--- a/Lab7-Integrate_LUIS/code/Finished/Responses/MainResponses.cs
+++ b/Lab7-Integrate_LUIS/code/Finished/Responses/MainResponses.cs
@@ -21,6 +21,7 @@ namespace PictureBot.Responses
         {
             // Add a response for the user if Regex or LUIS doesn't know
             // What the user is trying to communicate
+            await context.SendActivityAsync($"I'm not understand you.");
         }
         public static async Task ReplyWithLuisScore(ITurnContext context, string key, double score)
         {
@@ -30,6 +31,11 @@ namespace PictureBot.Responses
         {
             await context.SendActivityAsync($"Posting your picture(s) on twitter...");
         }
+        public static async Task ReplyWithSearchConfirmation(ITurnContext context)
+        {
+            await context.SendActivityAsync($"Searching your picture(s) on twitter...");
+        }
+        
         public static async Task ReplyWithOrderConfirmation(ITurnContext context)
         {
             await context.SendActivityAsync($"Ordering standard prints of your picture(s)...");

--- a/Lab7-Integrate_LUIS/code/Starter/PictureBot/PictureBot.csproj
+++ b/Lab7-Integrate_LUIS/code/Starter/PictureBot/PictureBot.csproj
@@ -7,9 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.Search" Version="9.1.0" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.5.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.5.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.7.2" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.5.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.5.1" />
   </ItemGroup>

--- a/Lab7-Integrate_LUIS/code/Starter/PictureBot/Responses/MainResponses.cs
+++ b/Lab7-Integrate_LUIS/code/Starter/PictureBot/Responses/MainResponses.cs
@@ -21,6 +21,7 @@ namespace PictureBot.Responses
         {
             // Add a response for the user if Regex or LUIS doesn't know
             // What the user is trying to communicate
+            await context.SendActivityAsync($"I'm not understand you.");
         }
         public static async Task ReplyWithLuisScore(ITurnContext context, string key, double score)
         {
@@ -30,6 +31,11 @@ namespace PictureBot.Responses
         {
             await context.SendActivityAsync($"Posting your picture(s) on twitter...");
         }
+        public static async Task ReplyWithSearchConfirmation(ITurnContext context)
+        {
+            await context.SendActivityAsync($"Searching your picture(s) on twitter...");
+        }
+        
         public static async Task ReplyWithOrderConfirmation(ITurnContext context)
         {
             await context.SendActivityAsync($"Ordering standard prints of your picture(s)...");


### PR DESCRIPTION
Please find following fixes: 
1. searchPic case is added for LOUIS because it setup in LAB 6 and need to be added to the code.
2. reference to the KeyVault Nuget Package updated because old reference generates an warning and highly likely went to the issues later.
3. When Bot confused is simply keep salient and not respond. The same situation happens when LUIS miss configured. So, students do not understand why the bot keep salient because it not understand or confused.
